### PR TITLE
Return parsed output as json

### DIFF
--- a/include-idl-cli/src/main.rs
+++ b/include-idl-cli/src/main.rs
@@ -25,9 +25,7 @@ pub fn main() -> Result<(), Error> {
         Some(Commands::Parse { path }) => {
             let buffer = std::fs::read(path).expect("Could not read file.");
             if let Ok((idl_type, idl_data)) = parse_idl_from_program_binary(&buffer) {
-                println!("Program IDL ({idl_type})");
-                println!("============================");
-                println!("\n{idl_data:#?}");
+                println!("\n[\"{idl_type}\", {idl_data}]");
             } else {
                 println!("Could not find IDL in program binary");
             }

--- a/include-idl/src/parse.rs
+++ b/include-idl/src/parse.rs
@@ -59,7 +59,15 @@ impl std::str::FromStr for IdlType {
 /// Parses the IDL data from the program binary.
 #[cfg(feature = "parse")]
 pub fn parse_idl_from_program_binary(buffer: &[u8]) -> goblin::error::Result<(IdlType, Value)> {
-    let elf = Elf::parse(buffer)?;
+    let elf = match Elf::parse(buffer) {
+        Ok(elf) => elf,
+        Err(e) => {
+            println!("Error parsing ELF: {}", e);
+            return Err(goblin::error::Error::Malformed(
+                "Could not parse ELF".to_string(),
+            ));
+        }
+    };
 
     let mut idl_type: Option<IdlType> = None;
     let mut idl_json: Option<Value> = None;


### PR DESCRIPTION
Ideally usage here with IDLs is actually

```bash
$ solana program dump <program-id> program.so
$ solana-include-idl-cli parse program.so | jq 'last' > idl.json
```
